### PR TITLE
BUGFIX: use .cjs for file extension of CJS variant (#7)

### DIFF
--- a/etc/vite.mts
+++ b/etc/vite.mts
@@ -33,7 +33,8 @@ export default Vite.defineConfig(({ command, mode }) => ({
             entry:    "dst/mqtt-json-rpc.js",
             formats:  formats.split(","),
             name:     "MqttJsonRpc",
-            fileName: (format) => `mqtt-json-rpc.${format === "es" ? "esm" : format}.js`
+            fileName: (format, entryName) =>
+                `mqtt-json-rpc.${format === "es" ? "esm" : format}.${format === "cjs" ? "cjs" : "js" }`
         },
         target:                 formats === "umd" ? "es2022" : "node20",
         outDir:                 "dst",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
     "type":                           "module",
     "types":                          "./dst/mqtt-json-rpc.d.ts",
     "module":                         "./dst/mqtt-json-rpc.esm.js",
-    "main":                           "./dst/mqtt-json-rpc.cjs.js",
+    "main":                           "./dst/mqtt-json-rpc.cjs.cjs",
     "browser":                        "./dst/mqtt-json-rpc.umd.js",
     "exports": {
         ".": {
             "import":                 { "types": "./dst/mqtt-json-rpc.d.ts", "default": "./dst/mqtt-json-rpc.esm.js" },
-            "require":                { "types": "./dst/mqtt-json-rpc.d.ts", "default": "./dst/mqtt-json-rpc.cjs.js" }
+            "require":                { "types": "./dst/mqtt-json-rpc.d.ts", "default": "./dst/mqtt-json-rpc.cjs.cjs" }
         }
     },
     "devDependencies": {


### PR DESCRIPTION
For this issue: https://github.com/rse/mqtt-json-rpc/issues/7
I applied the fix you did for your other package `mqtt-plus`: https://github.com/rse/mqtt-plus/commit/d1321f76a2504394296e2f2a80bc1be22ed71100